### PR TITLE
skip just that powerline import if issue with its points

### DIFF
--- a/import_osm_data.py
+++ b/import_osm_data.py
@@ -35,10 +35,10 @@ class PowerlineImporter(object):
                         nodes.append(node)
 
                 if flag:
-                    break
+                    continue
 
                 if len(nodes) < 2:
-                    break
+                    continue
 
                 linestring = ""
                 for node in nodes:


### PR DESCRIPTION
the break in the if clause will break the whole loop and skip the import
of the remaining powerlines. To actually skip just the powerline that
fails, we need to use +continue+ keyword instead of +break+
