### PR TITLE
Features/export relations in osm format

### DIFF
--- a/app/controllers/relations_controller.py
+++ b/app/controllers/relations_controller.py
@@ -32,8 +32,8 @@ class RelationsController:
             relations = Relation.relations_for_export(relations_ids)
 
         headers = {
-            'Content-Type': 'application/xml',
-            'Content-Disposition': 'attachment; filename=relations.xml'
+            'Content-Type': 'application/osm',
+            'Content-Disposition': 'attachment; filename=relations.xml.osm'
         }
 
         presenter = RelationsPresenter(relations)

--- a/app/controllers/relations_controller.py
+++ b/app/controllers/relations_controller.py
@@ -38,4 +38,4 @@ class RelationsController:
 
         presenter = RelationsPresenter(relations)
 
-        return Response(presenter.as_xml_element(), headers=headers)
+        return Response(presenter.as_osm_xml(), headers=headers)

--- a/app/presenters/relations_presenter.py
+++ b/app/presenters/relations_presenter.py
@@ -8,8 +8,11 @@ class RelationsPresenter:
     def __init__(self, relations):
         self.relations = relations
 
-    def as_xml_element(self):
-        osm_elem = Element('osm')
+    def as_osm_xml(self):
+        osm_elem = Element('osm', {
+            'version': '0.6',
+            'generator': 'PGIS:http://github.com/OpenGridMap/pgis'
+        })
 
         # ref_node_osmids: osm Ids of nodes that are part of a way
         # relation_member_node_osmids: osm Ids of nodes that are members of a relation

--- a/app/presenters/relations_presenter.py
+++ b/app/presenters/relations_presenter.py
@@ -1,5 +1,7 @@
 from xml.etree.ElementTree import Element, SubElement, Comment, tostring
 import json
+from app import db
+from sqlalchemy.sql import text
 
 # Presenter logic for Relations (plural).
 class RelationsPresenter:
@@ -7,53 +9,113 @@ class RelationsPresenter:
         self.relations = relations
 
     def as_xml_element(self):
-        relations_elem = Element('relations')
+        osm_elem = Element('osm')
+
+        # ref_node_osmids: osm Ids of nodes that are part of a way
+        # relation_member_node_osmids: osm Ids of nodes that are members of a relation
+        #   We remove relation_member_node_osmids from ref_node_osmids later in
+        #   the logic so that we don't repeat the same nodes in the XML.
+        ref_node_osmids = []
+        relation_member_node_osmids = []
 
         for relation_id, relation in self.relations.items():
-            relation_elem = SubElement(relations_elem, 'relation', {
-                'id': str(relation['id']),
-                'osmid': str(relation['properties']['osmid']),
+            relation_elem = SubElement(osm_elem, 'relation', {
+                'pgisId': str(relation['id']),
+                'id': str(relation['properties']['osmid']),
             })
             self.__buildXmlSubElementForTags(
                 relation['properties']['tags'],
                 relation_elem
             )
 
-            points_elem = SubElement(relation_elem, 'points')
             for point in relation['points']:
-                point_elem = SubElement(points_elem, 'point', {
+                point_elem = SubElement(osm_elem, 'node', {
                     'lat': str(point['latlng'][0]),
                     'lng': str(point['latlng'][1]),
-                    'osmid': str(point['properties']['osmid']),
-                    'id': str(point['id'])
+                    'id': str(point['properties']['osmid']),
+                    'pgisId': str(point['id'])
                 })
                 self.__buildXmlSubElementForTags(
                     point['properties']['tags'],
                     point_elem
                 )
+                relation_member_node_osmids.append(str(point['properties']['osmid']))
 
-            powerlines_elem = SubElement(relation_elem, 'powerlines')
-            for powerline in relation['powerlines']:
-                powerline_elem = SubElement(powerlines_elem, 'powerline', {
-                    'id': str(powerline['id'])
+                member_elem = SubElement(relation_elem, 'member', {
+                    'type': "node",
+                    'ref': str(point['properties']['osmid']),
+                    'role': ""
                 })
 
-                for latlng in powerline['latlngs']:
-                    latlng_elem = SubElement(powerline_elem, 'point', {
-                        'lat': str(latlng[0]),
-                        'lng': str(latlng[1])
+            for powerline in relation['powerlines']:
+
+                # our initial import scripts didn't import OSM IDs for powerlines
+                if 'osmid' in powerline['properties']:
+                    powerline_omsid = powerline['properties']['osmid']
+                else:
+                    powerline_omsid = "-1"
+
+                powerline_elem = SubElement(osm_elem, 'way', {
+                    'id': str(powerline_omsid),
+                    'pgisId': str(powerline['id'])
+                })
+
+                for point_id in powerline['properties']['refs']:
+                    ref_elem = SubElement(powerline_elem, 'nd', {
+                        'ref': str(point_id)
                     })
+                    ref_node_osmids.append(str(point_id))
 
                 self.__buildXmlSubElementForTags(
                     powerline['properties']['tags'],
                     powerline_elem
                 )
 
-        return tostring(relations_elem)
+                member_elem = SubElement(relation_elem, 'member', {
+                    'type': "way",
+                    'ref': str(powerline_omsid),
+                    'role': ""
+                })
+
+        to_be_added_nodes = list(set(ref_node_osmids) - set(relation_member_node_osmids))
+        ref_points = self.__points_with_osmids(to_be_added_nodes)
+
+        for ref_point in ref_points:
+            point_elem = SubElement(osm_elem, 'node', {
+                'lat': str(ref_point['latlng'][0]),
+                'lng': str(ref_point['latlng'][1]),
+                'id': str(ref_point['properties']['osmid']),
+                'pgisId': str(ref_point['id'])
+            })
+            self.__buildXmlSubElementForTags(
+                ref_point['properties']['tags'],
+                point_elem
+            )
+
+        return tostring(osm_elem)
 
     def __buildXmlSubElementForTags(self, tags, parent_xml_element):
         for tag, value in tags.items(): # tag.items() because tags is a dict
             tag_elem = SubElement(parent_xml_element, 'tag', {
-                'key': tag,
-                'value': value
+                'k': tag,
+                'v': value
             })
+
+    def __points_with_osmids(self, osmids):
+        query = text("""
+            SELECT p.id AS p_id, ST_X(p.geom) AS p_x, ST_Y(p.geom) AS p_y,
+                    p.properties AS p_prop
+            FROM point p
+            WHERE properties->>'osmid' IN :osm_ids
+        """)
+        point_rows = db.engine.execute(query, osm_ids = tuple(osmids))
+        ref_points = []
+        for row in point_rows:
+            ref_points.append({
+                'id': row['p_id'],
+                'latlng': [row['p_x'], row['p_y']],
+                'properties': row['p_prop']
+            })
+
+        return ref_points
+

--- a/app/presenters/relations_presenter.py
+++ b/app/presenters/relations_presenter.py
@@ -36,7 +36,7 @@ class RelationsPresenter:
             for point in relation['points']:
                 point_elem = SubElement(osm_elem, 'node', {
                     'lat': str(point['latlng'][0]),
-                    'lng': str(point['latlng'][1]),
+                    'lon': str(point['latlng'][1]),
                     'id': str(point['properties']['osmid']),
                     'pgisId': str(point['id']),
                     'version': "-1",
@@ -92,7 +92,7 @@ class RelationsPresenter:
         for ref_point in ref_points:
             point_elem = SubElement(osm_elem, 'node', {
                 'lat': str(ref_point['latlng'][0]),
-                'lng': str(ref_point['latlng'][1]),
+                'lon': str(ref_point['latlng'][1]),
                 'id': str(ref_point['properties']['osmid']),
                 'pgisId': str(ref_point['id']),
                 'version': "-1",
@@ -106,12 +106,14 @@ class RelationsPresenter:
 
         return tostring(osm_elem)
 
+
     def __buildXmlSubElementForTags(self, tags, parent_xml_element):
-        for tag, value in tags.items(): # tag.items() because tags is a dict
-            tag_elem = SubElement(parent_xml_element, 'tag', {
-                'k': tag,
-                'v': value
-            })
+        if tags is not None:
+            for tag, value in tags.items(): # tag.items() because tags is a dict
+                tag_elem = SubElement(parent_xml_element, 'tag', {
+                    'k': tag,
+                    'v': value
+                })
 
     def __points_with_osmids(self, osmids):
         query = text("""

--- a/app/presenters/relations_presenter.py
+++ b/app/presenters/relations_presenter.py
@@ -25,6 +25,8 @@ class RelationsPresenter:
             relation_elem = SubElement(osm_elem, 'relation', {
                 'pgisId': str(relation['id']),
                 'id': str(relation['properties']['osmid']),
+                'version': "-1",
+                'timestamp': ""
             })
             self.__buildXmlSubElementForTags(
                 relation['properties']['tags'],
@@ -36,7 +38,9 @@ class RelationsPresenter:
                     'lat': str(point['latlng'][0]),
                     'lng': str(point['latlng'][1]),
                     'id': str(point['properties']['osmid']),
-                    'pgisId': str(point['id'])
+                    'pgisId': str(point['id']),
+                    'version': "-1",
+                    'timestamp': ""
                 })
                 self.__buildXmlSubElementForTags(
                     point['properties']['tags'],
@@ -60,7 +64,9 @@ class RelationsPresenter:
 
                 powerline_elem = SubElement(osm_elem, 'way', {
                     'id': str(powerline_omsid),
-                    'pgisId': str(powerline['id'])
+                    'pgisId': str(powerline['id']),
+                    'version': "-1",
+                    'timestamp': ""
                 })
 
                 for point_id in powerline['properties']['refs']:
@@ -88,7 +94,10 @@ class RelationsPresenter:
                 'lat': str(ref_point['latlng'][0]),
                 'lng': str(ref_point['latlng'][1]),
                 'id': str(ref_point['properties']['osmid']),
-                'pgisId': str(ref_point['id'])
+                'pgisId': str(ref_point['id']),
+                'version': "-1",
+                'timestamp': ""
+
             })
             self.__buildXmlSubElementForTags(
                 ref_point['properties']['tags'],

--- a/import_osm_data.py
+++ b/import_osm_data.py
@@ -87,7 +87,7 @@ class PowerlineImporter(object):
                 '''
                 cur.execute(query, [
                     'LINESTRING({})'.format(linestring),
-                    json.dumps({ "tags": tags, "refs": refs }),
+                    json.dumps({ "tags": tags, "refs": refs, "osmid": str(osmid) }),
                     'LINESTRING({})'.format(linestring),
                 ])
 

--- a/import_osm_data.py
+++ b/import_osm_data.py
@@ -56,8 +56,6 @@ class PowerlineImporter(object):
                         # if couldn't find in point table. Find in temp_point
                         #   table, move that to point table.
                         node = tempPointHelper.find_with_osmid(str(ref))
-                        if node is not None:
-                            tempPointHelper.copy_to_actual_point_table(str(ref))
 
                     if node is None:
                         flag = True

--- a/import_osm_relations.py
+++ b/import_osm_relations.py
@@ -185,7 +185,7 @@ class PowerlineImporter(object):
                     query = "INSERT INTO powerline(geom, properties) VALUES(%s, %s)"
                     query_values = [
                         'LINESTRING({})'.format(linestring),
-                        json.dumps({ "tags": tags, "refs": refs })
+                        json.dumps({ "tags": tags, "refs": refs, "osmid": str(osmid) })
                     ]
                     cur.execute(query, query_values)
 
@@ -195,7 +195,9 @@ class PowerlineImporter(object):
                         "WHERE member_osm_id = %s"
                     cur.execute(join_table_update_query, [str(osmid)])
             else:
-                print("\nHaven't found relation for powerline - osmid %s" % osmid)
+                # It could be that this line doesn't belong to a relation that
+                #   is tagged with "power".
+                print("\nHaven't found relation for line - osmid %s" % osmid)
 
 class RelationsImporter(object):
 


### PR DESCRIPTION
Can now exports relations in the OSM XML Format -> http://wiki.openstreetmap.org/wiki/OSM_XML

Things to have in mind: 
- The export format from OSM requires all the nodes that are a part of ways to be referenced with OSMID under the `way` node as `ref` nodes in the XML and an actual NODE (point) element is added to the XML. For us to do that, we don’t actually import the points if they don’t have a power tag even if they are a part of a line.
